### PR TITLE
rodar aplicacao em modo dev pra visualizar a pagina do swagger

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,10 @@ services:
     depends_on:
       - databasesqlserver
     environment:
+      ASPNETCORE_ENVIRONMENT: Development
       SQLServerConnection: "Data Source=databasesqlserver;Initial Catalog=ByteMeBurguer;TrustServerCertificate=True;Persist Security Info=True;User ID=SA;Password=TechChallenge#api"
     ports:
-      - 5001:80
+      - 5001:8080
       
   databasesqlserver:
     image: mcr.microsoft.com/mssql/server:2019-latest


### PR DESCRIPTION
nao e possivel visualizar o swager pois ha o filtro no program.cs para exibir apenas quando estiver em modo dev.

a solucao e remove o filtro ou adicionar a variavel de ambiente.

tamem precisa alterar o mapeamento da porta, por padrao essa imagem do .net expoe a porta 8080 e nao 80